### PR TITLE
DEVEL-7581 pcov coverage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # for newest, check: https://hub.docker.com/_/php?tab=tags
 #FROM php:8.3.2-fpm-bookworm - még nem megy 2024-01-30
-FROM php:8.2.16-fpm-bookworm
+FROM php:8.2.23-fpm-bookworm
 
 # log to stdout -> TODO: to nginx too - this is not intentional, but fine for now
 RUN echo "php_admin_flag[log_errors] = on" >> /usr/local/etc/php-fpm.conf
@@ -18,57 +18,58 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends gnupg2
 # temporary
 COPY mssql_pin /etc/apt/preferences.d/microsoft
 
+# pcov.ini
+COPY pcov.ini.disabled /usr/local/etc/php/conf.d/pcov.ini.disabled
+
 # sqlsrv - https://laravel-news.com/install-microsoft-sql-drivers-php-7-docker
 # msodbcsql18 - https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver16#debian18
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-#    curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
-    curl https://packages.microsoft.com/config/ubuntu/22.10/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
-    apt-get update
-
-# gosu: run final command as www-data if needed
-
-RUN apt-get install -y -q --no-install-recommends \
-    gosu \
-    cron \
-    nano \
-    procps \
-    iputils-ping \
-    ffmpeg \
-    rsync \
-    less \
-    pv \
-    git \
-    msmtp \
-    default-mysql-client \
-    curl \
-    imagemagick \
-    zlib1g-dev \
-    libpng-dev \
-    libwebp-dev \
-    libgmp-dev \
-    libjpeg62-turbo-dev \
-    libfreetype6-dev \
-    libzip-dev \
-    libmagickwand-dev \
-    libxml2-dev \
-    libldap-dev \
-    libltdl-dev \
-    libpq-dev \
-    unixodbc-dev \
-    msodbcsql18 \
-    openssh-client \
-    locales \
-    libfcgi-bin \
-    strace \
-    wget
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+#   && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/ubuntu/22.10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update \
+    && apt-get install -y -q --no-install-recommends \
+        # gosu: run final command as www-data if needed
+        gosu \
+        cron \
+        nano \
+        procps \
+        iputils-ping \
+        ffmpeg \
+        rsync \
+        less \
+        pv \
+        git \
+        msmtp \
+        default-mysql-client \
+        curl \
+        imagemagick \
+        zlib1g-dev \
+        libpng-dev \
+        libwebp-dev \
+        libgmp-dev \
+        libjpeg62-turbo-dev \
+        libfreetype6-dev \
+        libzip-dev \
+        libmagickwand-dev \
+        libxml2-dev \
+        libldap-dev \
+        libltdl-dev \
+        libpq-dev \
+        unixodbc-dev \
+        msodbcsql18 \
+        openssh-client \
+        locales \
+        libfcgi-bin \
+        strace \
+        wget
 
 # ffmpeg multimedia package install (https://www.deb-multimedia.org/) - for example the default ffmpeg lib is not containts zscale
-RUN echo "deb https://www.deb-multimedia.org bookworm main non-free" >> /etc/apt/sources.list
-RUN wget https://www.deb-multimedia.org/pool/main/d/deb-multimedia-keyring/deb-multimedia-keyring_2016.8.1_all.deb
-RUN dpkg -i deb-multimedia-keyring_2016.8.1_all.deb
-RUN rm deb-multimedia-keyring_2016.8.1_all.deb
-RUN apt update
-RUN apt install -y ffmpeg
+RUN echo "deb https://www.deb-multimedia.org bookworm main non-free" >> /etc/apt/sources.list \
+    && wget https://www.deb-multimedia.org/pool/main/d/deb-multimedia-keyring/deb-multimedia-keyring_2016.8.1_all.deb \
+    && dpkg -i deb-multimedia-keyring_2016.8.1_all.deb \
+    && rm deb-multimedia-keyring_2016.8.1_all.deb \
+    && apt update \
+    && apt install -y ffmpeg
 
 # https://stackoverflow.com/questions/27931668/encoding-problems-when-running-an-app-in-docker-python-java-ruby-with-u/27931669
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen && apt-get clean && rm -r /var/lib/apt/lists/*
@@ -76,16 +77,16 @@ RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen && apt-get clean &&
 ENV LC_ALL=en_US.UTF-8
 
 # redis: https://stackoverflow.com/questions/31369867/how-to-install-php-redis-extension-using-the-official-php-docker-image-approach
-RUN pecl install sqlsrv pdo_sqlsrv redis imagick && rm -rf /tmp/pear
+RUN pecl install sqlsrv pcov pdo_sqlsrv redis imagick && rm -rf /tmp/pear
 
-RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h && \
-    docker-php-ext-configure gd \
-      --with-freetype=/usr/include/ \
-      --with-jpeg=/usr/include/ \
-      --with-webp=/usr/include/ \
-     && \
-    docker-php-ext-configure opcache --enable-opcache && \
-    docker-php-ext-install -j5 ftp iconv pdo_mysql pdo_pgsql zip gmp mysqli gd soap exif intl sockets bcmath ldap pcntl opcache
+RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h \
+    && docker-php-ext-configure gd \
+        --with-freetype=/usr/include/ \
+        --with-jpeg=/usr/include/ \
+        --with-webp=/usr/include/ \
+    \
+    && docker-php-ext-configure opcache --enable-opcache \
+    && docker-php-ext-install -j5 ftp iconv pdo_mysql pdo_pgsql zip gmp mysqli gd soap exif intl sockets bcmath ldap pcntl opcache
 
 RUN docker-php-ext-enable sqlsrv pdo_sqlsrv redis imagick
 
@@ -110,10 +111,10 @@ RUN echo "host smtp\nport 25\nadd_missing_from_header on\nfrom dev@dblaci.hu\n" 
 COPY msmtp.conf /usr/local/etc/php/conf.d/mail.ini
 
 ARG wwwdatauid=1000
-RUN usermod -u $wwwdatauid www-data
+RUN usermod -u "$wwwdatauid" www-data
 
 # for componser cache
-RUN chown $wwwdatauid:$wwwdatauid /var/www
+RUN chown "$wwwdatauid":"$wwwdatauid" /var/www
 
 COPY docker-php-entrypoint /usr/local/bin/docker-php-entrypoint
 COPY check_env.sh /usr/local/bin/check_env.sh
@@ -121,5 +122,5 @@ COPY check_env.sh /usr/local/bin/check_env.sh
 # Enable php fpm status page
 RUN echo "pm.status_path = /status" >> /usr/local/etc/php-fpm.conf
 
-# Copy healtcheck script
+# Copy healthcheck script
 COPY ./php-fpm-healthcheck /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,45 +23,47 @@ COPY pcov.ini.disabled /usr/local/etc/php/conf.d/pcov.ini.disabled
 
 # sqlsrv - https://laravel-news.com/install-microsoft-sql-drivers-php-7-docker
 # msodbcsql18 - https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver16#debian18
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-#   && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
-    && curl https://packages.microsoft.com/config/ubuntu/22.10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
-    && apt-get update \
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+#    curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    curl https://packages.microsoft.com/config/ubuntu/22.10/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update \
+
+# gosu: run final command as www-data if needed
+
     && apt-get install -y -q --no-install-recommends \
-        # gosu: run final command as www-data if needed
-        gosu \
-        cron \
-        nano \
-        procps \
-        iputils-ping \
-        ffmpeg \
-        rsync \
-        less \
-        pv \
-        git \
-        msmtp \
-        default-mysql-client \
-        curl \
-        imagemagick \
-        zlib1g-dev \
-        libpng-dev \
-        libwebp-dev \
-        libgmp-dev \
-        libjpeg62-turbo-dev \
-        libfreetype6-dev \
-        libzip-dev \
-        libmagickwand-dev \
-        libxml2-dev \
-        libldap-dev \
-        libltdl-dev \
-        libpq-dev \
-        unixodbc-dev \
-        msodbcsql18 \
-        openssh-client \
-        locales \
-        libfcgi-bin \
-        strace \
-        wget
+    gosu \
+    cron \
+    nano \
+    procps \
+    iputils-ping \
+    ffmpeg \
+    rsync \
+    less \
+    pv \
+    git \
+    msmtp \
+    default-mysql-client \
+    curl \
+    imagemagick \
+    zlib1g-dev \
+    libpng-dev \
+    libwebp-dev \
+    libgmp-dev \
+    libjpeg62-turbo-dev \
+    libfreetype6-dev \
+    libzip-dev \
+    libmagickwand-dev \
+    libxml2-dev \
+    libldap-dev \
+    libltdl-dev \
+    libpq-dev \
+    unixodbc-dev \
+    msodbcsql18 \
+    openssh-client \
+    locales \
+    libfcgi-bin \
+    strace \
+    wget
 
 # ffmpeg multimedia package install (https://www.deb-multimedia.org/) - for example the default ffmpeg lib is not containts zscale
 RUN echo "deb https://www.deb-multimedia.org bookworm main non-free" >> /etc/apt/sources.list \
@@ -79,14 +81,14 @@ ENV LC_ALL=en_US.UTF-8
 # redis: https://stackoverflow.com/questions/31369867/how-to-install-php-redis-extension-using-the-official-php-docker-image-approach
 RUN pecl install sqlsrv pcov pdo_sqlsrv redis imagick && rm -rf /tmp/pear
 
-RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h \
-    && docker-php-ext-configure gd \
-        --with-freetype=/usr/include/ \
-        --with-jpeg=/usr/include/ \
-        --with-webp=/usr/include/ \
-    \
-    && docker-php-ext-configure opcache --enable-opcache \
-    && docker-php-ext-install -j5 ftp iconv pdo_mysql pdo_pgsql zip gmp mysqli gd soap exif intl sockets bcmath ldap pcntl opcache
+RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h && \
+    docker-php-ext-configure gd \
+      --with-freetype=/usr/include/ \
+      --with-jpeg=/usr/include/ \
+      --with-webp=/usr/include/ \
+     && \
+    docker-php-ext-configure opcache --enable-opcache && \
+    docker-php-ext-install -j5 ftp iconv pdo_mysql pdo_pgsql zip gmp mysqli gd soap exif intl sockets bcmath ldap pcntl opcache
 
 RUN docker-php-ext-enable sqlsrv pdo_sqlsrv redis imagick
 

--- a/check_env.sh
+++ b/check_env.sh
@@ -3,7 +3,11 @@
 # Note: this file is only reasonable with the php-fpm, not the docker run/docker exec mode. So it is running only if the user is root!
 
 if [ "${XDEBUG_ENABLE}" == "1" ]; then
-  mv /usr/local/etc/php/conf.d/xdebug.ini.disable /usr/local/etc/php/conf.d/xdebug.ini
+    mv /usr/local/etc/php/conf.d/xdebug.ini.disabled /usr/local/etc/php/conf.d/xdebug.ini
+fi
+
+if [ "${PCOV_ENABLE}" == "1" ]; then
+    mv /usr/local/etc/php/conf.d/pcov.ini.disabled /usr/local/etc/php/conf.d/pcov.ini
 fi
 
 if [ "${PHP_PRODUCTION}" == "1" ]; then

--- a/pcov.ini.disabled
+++ b/pcov.ini.disabled
@@ -1,0 +1,5 @@
+extension=pcov.so
+pcov.enabled=1
+memory_limit=512M
+pcov.directory="/var/www/html"
+pcov.exclude="#/(assets|_bin|crontabs|_doc|_docker|helm.DEPRECATED|_lib|node_modules|openapi|public|scss|src_admin|src_new|src_service|templates|tests|vue|webpack_config)/#"


### PR DESCRIPTION
Hi.

Updated the image to the latest.

I added a new environment variable to allow for enabling code-coverage measurement in CI/CD.

I made the apt-get update happen in the same layer as the apt-get install because I have previously had problems with the apt-get update layer getting cached and then the apt-get install failing due to the update being out of date.

The check_env.sh couldn't have worked previously, because the file name was incorrect, and in my code-coverage testing, the mv failed with file not found, so I fixed the existing XDEBUG example and added the new pcov one.

I quote the shell variables and made the && be consistent as to whether it was at the front or end of the line.

I am not convinced that the pcov.exclude line adds anything, but the pcov.directory line was the key to the "only works on my machine" problem I was having, and the documentation recommended including pcov.exclude if you include pcov.directory.

I have tested locally that the code coverage works with the new image without running the installation script after each docker-compose up that was previously needed.
